### PR TITLE
Arbiter: support the entering of new players lazily

### DIFF
--- a/Mom/AssemblyInfo.fs
+++ b/Mom/AssemblyInfo.fs
@@ -16,8 +16,8 @@ open System.Runtime.CompilerServices
 [<assembly: ComVisible(false)>]
 [<assembly: Guid("7acec947-9a6a-4c15-aaeb-b56f3242c59e")>]
 
-[<assembly: AssemblyVersion("0.5.0.0")>]
-[<assembly: AssemblyFileVersion("0.5.0.0")>]
+[<assembly: AssemblyVersion("0.6.0.0")>]
+[<assembly: AssemblyFileVersion("0.6.0.0")>]
 
 [<assembly: InternalsVisibleTo("Mom.Tests")>]
 


### PR DESCRIPTION
This is an experiment to allow a bit more flexibility when new players are added to a field. 

Sometimes it's desirable to add new players at the end of the current round to allow the current players to finish their synchronous, blocking work or to end field before the new players are event started. 
