### PR TITLE
Async request context

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "paket": {
-      "version": "5.255.0",
+      "version": "7.0.2",
       "commands": [
         "paket"
       ]

--- a/Mom.Tests/InlineRequests.fs
+++ b/Mom.Tests/InlineRequests.fs
@@ -1,0 +1,36 @@
+﻿/// Tests inline requests
+module Mom.Tests.InlineRequests
+
+open System
+open FsUnit
+open Xunit
+open Mom
+
+type InlineRequest(value: int) =
+    interface IInlineRequest<string, int> with
+        override _.Execute(str: string) =
+            (int str) + value
+
+type InlineAsyncRequest(value: int) =
+    interface IInlineAsyncRequest<string, int> with
+        override _.Execute(str: string) = async {
+            return (int str) + value
+        }
+
+[<Fact>]
+let ``simple inline request with context``() =
+
+    let context = "100"
+    let runtime = 
+        Runtime.defaultBuilder
+        |> Runtime.withService (InlineRequestService.create context)
+        |> Runtime.build
+
+    
+    mom {
+        let! r = InlineRequest(10)
+        r |> should equal 110
+        let! r = InlineAsyncRequest(11)
+        r |> should equal 111
+    }
+    |> runtime.Run

--- a/Mom.Tests/Mom.Tests.fsproj
+++ b/Mom.Tests/Mom.Tests.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="MomGCTests.fs" />
     <Compile Include="TracingTests.fs" />
     <Compile Include="RuntimeTests.fs" />
+    <Compile Include="InlineRequests.fs" />
     <Compile Include="SystemTests.fs" />
     <Content Include="paket.references" />
     <Content Include="app.config" />

--- a/Mom.Tests/Mom.Tests.fsproj
+++ b/Mom.Tests/Mom.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>

--- a/Mom.Tests/SystemTests.fs
+++ b/Mom.Tests/SystemTests.fs
@@ -20,7 +20,7 @@ let canGetMethodInfoFromGenericModuleFunctionViaQuotations() =
     let mi = 
         match exp with
         | Patterns.Call(_, mi, _) -> mi
-        | _ -> failwith "internal error"
+        | _ -> failwith "Internal error"
 
     mi.Name |> should equal "someGenericFunction"
     mi.IsGenericMethod |> should equal true
@@ -43,7 +43,7 @@ let canGetMethodInfoFromGenericModuleFunctionWithParameterViaQuotations() =
     let mi = 
         match exp with
         | Patterns.Call(_, mi, _) -> mi
-        | _ -> failwith "internal error"
+        | _ -> failwith "Internal error"
 
     mi.Name |> should equal "someGenericFunction2"
     mi.IsGenericMethod |> should equal true

--- a/Mom.Tests/TracingTests.fs
+++ b/Mom.Tests/TracingTests.fs
@@ -19,7 +19,7 @@ type ConvertIntToStr =
 let respond r =
     function 
     | Flux.Requesting (_, cont) -> cont (r |> box |> Flux.Value)
-    | _ -> failwith "internal error"
+    | _ -> failwith "Internal error"
 
 /// Mom under test.
 let mom p = mom {
@@ -82,7 +82,7 @@ let replayReplaysCommandResponses() =
         | :? ConvertIntToStr as ci ->
             let (ConvertIntToStr i) = ci
             i.ToString() |> box
-        | _ -> failwith "internal error"
+        | _ -> failwith "Internal error"
 
     let mom = mom {
         return! Mom.send (ConvertIntToStr 10)

--- a/Mom/InlineRequestService.fs
+++ b/Mom/InlineRequestService.fs
@@ -107,7 +107,7 @@ module private ExecuteWrapperAsync =
             t.GetInterfaces()
             |> Seq.find(fun i -> i.IsGenericType && i.GetGenericTypeDefinition() = inlineAsyncRequestGenericTypeDefinition)
 
-        genericInterface.GetGenericArguments().[0]
+        genericInterface.GetGenericArguments().[1]
 
     type ExecuteF<'context> = IInlineAsyncRequest<'context> -> 'context -> Async<obj>
 

--- a/Mom/InlineRequestService.fs
+++ b/Mom/InlineRequestService.fs
@@ -146,7 +146,7 @@ module private ExecuteWrapper =
         let exp = <@@ wrap<'context, obj>((box null) :?> IInlineRequest<'context>) @@>
         match exp with
         | Patterns.Call(_, mi, _) -> mi.GetGenericMethodDefinition()
-        | _ -> failwith "internal error"
+        | _ -> failwith "Internal error"
 
     let resolveResponseType (t: Type) : Type = 
         let genericInterface = 

--- a/Mom/Mom.fs
+++ b/Mom/Mom.fs
@@ -315,7 +315,7 @@ module Mom =
     /// finally returned, because the remaining moms may refuse to get cancelled.
     let race (moms: 'r mom list) : 'r mom =
         if List.isEmpty moms then
-            failwith "internal error: Mom.race with zero nested moms would be unsound."
+            failwith "Internal error: Mom.race with zero nested moms would be unsound."
 
         // Note: when an mom finishes, all the running ones are canceled in the reversed 
         // order they were originally specified in the list 
@@ -345,7 +345,7 @@ module Mom =
         |> all
         |> map (function 
             | [l;r] -> unbox l, unbox r 
-            | _ -> failwith "internal error")
+            | _ -> failwith "Internal error")
 
     /// Runs two moms in parallel, the resulting mom completes with the result of the one that finishes first.
     /// events are delivered to mom1 and then to mom2, so mom1 has an advantage when both complete in response to

--- a/Mom/Mom.fsproj
+++ b/Mom/Mom.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Description>F# computation expressions and combinators for deterministic coordination, simulation, and testing of concurrent processes.</Description>
     <PackageProjectUrl>https://github.com/pragmatrix/mom</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pragmatrix/mom</RepositoryUrl>

--- a/Mom/Mom.fsproj
+++ b/Mom/Mom.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>0.8.0</Version>
+    <Version>0.10.0</Version>
     <Description>F# computation expressions and combinators for deterministic coordination, simulation, and testing of concurrent processes.</Description>
     <PackageProjectUrl>https://github.com/pragmatrix/mom</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pragmatrix/mom</RepositoryUrl>

--- a/Mom/Runtime.fs
+++ b/Mom/Runtime.fs
@@ -119,7 +119,7 @@ let withFunction (f: 'request -> 'r when 'request :> Mom.IRequest<'r>) =
 
     withService service
 
-let create builder = 
+let build (builder: Builder) = 
 
     let services = builder.Services |> List.rev
 
@@ -134,6 +134,9 @@ let create builder =
             | Some response -> response
 
     new Runtime (builder.EventQueue, serviceHost)
+
+[<Obsolete("Use Runtime.build")>]
+let create builder = build builder
 
 /// Some predefined services that should be supported by every runtime.
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
@@ -226,5 +229,5 @@ let defaultBuilder =
 let newRuntime hostService = 
     defaultBuilder
     |> withService hostService
-    |> create
+    |> build
     

--- a/Mom/Runtime.fs
+++ b/Mom/Runtime.fs
@@ -42,7 +42,7 @@ type Runtime internal (eventQueue: SynchronizedQueue<Flux.Event>, host: IService
     member private this.Cancel() = 
         this.ScheduleEvent CancelMom
 
-    /// Runs the mom synchronously. Returns Some value or None if the mom was cancelled.
+    /// Runs the mom synchronously. Returns `Some(value)` or `None` if the mom was cancelled.
     member __.Run mom = 
 
         let rec runLoop flux =
@@ -163,9 +163,7 @@ module Service =
             match cmd with
             | :? Mom.IAsyncComputation as ac -> 
                 let id = asyncIdGenerator.GenerateId()
-                ac.Run(fun r ->
-                    context.ScheduleEvent (Mom.AsyncComputationCompleted(id, r))
-                    )
+                ac.Run(fun r -> Mom.AsyncComputationCompleted(id, r) |> context.ScheduleEvent)
                 id |> box |> Some
             | _ -> None
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,6 +1,6 @@
 source https://www.nuget.org/api/v2/
 
-framework: netstandard2.0,netcoreapp3.1
+framework: netstandard2.0,net6.0
 
-nuget FSharp.Core ~> 4.7.2
+nuget FSharp.Core ~> 6.0.3
 nuget FsUnit.xUnit ~> 4.0.2

--- a/paket.lock
+++ b/paket.lock
@@ -1,7 +1,7 @@
 RESTRICTION: || (== net6.0) (== netstandard2.0)
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (4.7.2)
+    FSharp.Core (6.0.3)
     FsUnit.xUnit (4.0.7)
       FSharp.Core (>= 4.7.2)
       NETStandard.Library (>= 2.0.3)

--- a/paket.lock
+++ b/paket.lock
@@ -1,9 +1,9 @@
-RESTRICTION: || (== netcoreapp3.1) (== netstandard2.0)
+RESTRICTION: || (== net6.0) (== netstandard2.0)
 NUGET
   remote: https://www.nuget.org/api/v2
     FSharp.Core (4.7.2)
-    FsUnit.xUnit (4.0.2)
-      FSharp.Core (>= 4.3.4)
+    FsUnit.xUnit (4.0.7)
+      FSharp.Core (>= 4.7.2)
       NETStandard.Library (>= 2.0.3)
       NHamcrest (>= 2.0.1 < 2.1)
       xunit (>= 2.4.1 < 2.5)


### PR DESCRIPTION
This PR adds a context variable to all Inline async and blocking IVR requests. The context is needed in the IVR project to be able to pass a logging instance to the `Execute` function.