### PR TITLE
Try not to share builder's event queue.

### DIFF
--- a/Mom.Tests/InlineRequests.fs
+++ b/Mom.Tests/InlineRequests.fs
@@ -22,7 +22,7 @@ let ``simple inline request with context``() =
 
     let context = "100"
     let runtime = 
-        Runtime.defaultBuilder
+        Runtime.newDefaultBuilder()
         |> Runtime.withService (InlineRequestService.create context)
         |> Runtime.build
 

--- a/Mom/Flux.fs
+++ b/Mom/Flux.fs
@@ -27,7 +27,7 @@ module Flux =
     type Response = obj
     type Event = obj
 
-    [<NoComparison;NoEquality>] 
+    [<NoComparison; NoEquality>] 
     type 'result flux =
         | Requesting of Request * (Response result -> 'result flux)
         | Waiting of (Event -> 'result flux)

--- a/Mom/Mom.fsproj
+++ b/Mom/Mom.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
     <Description>F# computation expressions and combinators for deterministic coordination, simulation, and testing of concurrent processes.</Description>
     <PackageProjectUrl>https://github.com/pragmatrix/mom</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pragmatrix/mom</RepositoryUrl>


### PR DESCRIPTION
The current syntax for creating builders makes it easy to accidentally share the EventQueue that is responsible to deliver external events back into the runtime. This can have dramatic effects when more than one runtime is running in the same process.

This PR mitigates the problem by only offering a `newBuilder()` method instead of a `builder` that returns an event queue which may be accidentally be shared.
