### PR TITLE
Further optimize the runtime by declaring more types as structs keeping

### DIFF
--- a/Mom/AsyncService.fs
+++ b/Mom/AsyncService.fs
@@ -14,7 +14,7 @@ type internal UnsafeRegistry = {
     OnException: exn -> unit
 }
 
-[<RequireQualifiedAccess>]
+[<Struct; RequireQualifiedAccess>]
 type JoinResult = 
     | Timeout
     | Completed

--- a/Mom/Flux.fs
+++ b/Mom/Flux.fs
@@ -1,6 +1,5 @@
 ﻿namespace Mom
 
-open System
 open System.Runtime.ExceptionServices
 
 module Flux =
@@ -27,11 +26,11 @@ module Flux =
     type Response = obj
     type Event = obj
 
-    [<NoComparison; NoEquality>] 
+    [<Struct; NoComparison; NoEquality>] 
     type 'result flux =
-        | Requesting of Request * (Response result -> 'result flux)
-        | Waiting of (Event -> 'result flux)
-        | Completed of 'result result
+        | Requesting of _request: Request * (Response result -> 'result flux)
+        | Waiting of _waiting: (Event -> 'result flux)
+        | Completed of _result: 'result result
 
     /// Dispatch an event to the flux that is currently waiting for one.
     let dispatch ev = function
@@ -80,6 +79,7 @@ module Flux =
         | _ -> false
 
     /// The event that is sent to a flux when it gets cancelled.
+    [<Struct>]
     type Cancel = Cancel
 
     exception AsynchronousCancellationException with

--- a/Mom/Ids.fs
+++ b/Mom/Ids.fs
@@ -2,6 +2,7 @@
 
 open System.Threading
 
+[<Struct>]
 type Id = 
     | Id of int64
     member this.Value = let (Id v) = this in v
@@ -10,6 +11,7 @@ type Id =
 [<RequireQualifiedAccess>]
 module Ids =
     
+    [<Struct>]
     type Generator = {
         Id: int64 ref
     } with 

--- a/Mom/Mom.fs
+++ b/Mom/Mom.fs
@@ -116,17 +116,17 @@ module Mom =
     /// The priority with which new players should enter the field.
     ///
     /// Experimental.
-    [<RequireQualifiedAccess; Struct>]
+    [<Struct; RequireQualifiedAccess>]
     type EnteringPriority = 
         /// Default: New players are immediately entering the field to replace the player that has exited before.
         | Now
         /// New players are added to field as soon all current players are in the waiting state.
         | Lazy
 
-    [<NoComparison;NoEquality>]
+    [<Struct; NoComparison; NoEquality>]
     type ArbiterDecision<'state, 'r> = 
-        | CancelField of 'state result
-        | ContinueField of 'state * EnteringPriority * 'r mom list
+        | CancelField of cancel: 'state result
+        | ContinueField of cont: 'state * EnteringPriority * 'r mom list
 
     /// Cancel all remaining Moms and set the result of the field mom
     let inline cancelField r = CancelField r
@@ -144,7 +144,7 @@ module Mom =
     // a waiting mom
     type private 'result waiting = Event -> 'result flux
 
-    [<NoEquality; NoComparison>]
+    [<Struct; NoEquality; NoComparison>]
     type private Field<'state, 'r> = {
         State: 'state
         /// The current event and waiting moms that need to receive it.
@@ -503,7 +503,7 @@ module Mom =
     type IAsyncRequest<'response> = 
         interface end
 
-    [<NoComparison>]
+    [<Struct; NoComparison>]
     type AsyncResponse<'response> = 
         | AsyncResponse of Id * 'response result
 
@@ -614,14 +614,17 @@ module Mom =
     // Mom System Requests & Events
     //
 
+    [<Struct>]
     type Delay = 
         | Delay of TimeSpan
         interface IRequest<Id>
-    
+
+    [<Struct>]    
     type CancelDelay = 
         | CancelDelay of Id
         interface IRequest<unit>
 
+    [<Struct>]
     type DelayCompleted = DelayCompleted of Id
 
     /// Wait for the given time span and continue then.
@@ -674,8 +677,9 @@ module Mom =
 
         interface IRequest<Id>
 
-    [<NoComparison>]
-    type AsyncComputationCompleted = AsyncComputationCompleted of id: Id * result: obj result
+    [<Struct; NoComparison>]
+    type AsyncComputationCompleted = 
+        | AsyncComputationCompleted of id: Id * result: obj result
 
     /// Waits for an F# asynchronous computation.
     let await (computation: Async<'r>) : 'r mom = mom {

--- a/Mom/Runtime.fs
+++ b/Mom/Runtime.fs
@@ -88,7 +88,7 @@ type Runtime internal (eventQueue: SynchronizedQueue<Flux.Event>, host: IService
 type Service = IServiceContext -> Flux.Request -> Flux.Response option
         
 /// A builder that supports the creation of runtimes and adding services to it.
-[<NoComparison; NoEquality; Struct>]
+[<Struct; NoComparison; NoEquality>]
 type Builder = {
     EventQueue: SynchronizedQueue<Flux.Event>
     Services: Service list
@@ -200,7 +200,7 @@ module Service =
 
     let disabled _ _ = None
 
-    [<NoComparison; NoEquality; Struct>]
+    [<Struct; NoComparison; NoEquality>]
     type ServiceCrashResponse =
         /// Return the response and continue the service that crashed
         | ContinueService

--- a/Mom/Sideshow.fs
+++ b/Mom/Sideshow.fs
@@ -15,14 +15,15 @@ open Mom.GlobalExports
 
 /// This is the control interface for the side show.
 
+[<Struct>]
 type Control<'state>(doBegin: 'state * unit mom -> unit mom, getState: unit -> 'state option mom) =
     /// Cancel and replace the side show mom that is tagged with the given state. 
     /// This mom returns after the
     /// currently running side show mom is cancelled and the new one is started (gets into
     /// a waiting state or completed). Errors are propagated to the mom of the caller.
-    member this.Begin(state, mom) = doBegin(state, mom)
+    member _.Begin(state, mom) = doBegin(state, mom)
     /// Returns the state of the sideshow, or None if the sideshow is not active.
-    member this.State with get() = getState()
+    member _.State with get() = getState()
 
 type Control<'state> with
     /// End the sideshow by cancelling the current mom, which sets the state to None.
@@ -36,10 +37,10 @@ type Control<'state> with
 module private Private = 
     let generateId = Ids.newGenerator().GenerateId
 
-    [<NoEquality;NoComparison>]
+    [<Struct; NoEquality; NoComparison>]
     type Request<'state> = 
-        | Replace of Id * ('state * unit mom)
-        | GetState of Id
+        | Replace of _replace: Id * ('state * unit mom)
+        | GetState of _getState: Id
 
     type 'r flux = 'r Flux.flux
 


### PR DESCRIPTION
allocations to a minimum