### PR TITLE
Introduce Reflector.wrapReceiver

### DIFF
--- a/Mom/Mom.fsproj
+++ b/Mom/Mom.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Description>F# computation expressions and combinators for deterministic coordination, simulation, and testing of concurrent processes.</Description>
     <PackageProjectUrl>https://github.com/pragmatrix/mom</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pragmatrix/mom</RepositoryUrl>

--- a/Mom/Reflector.fs
+++ b/Mom/Reflector.fs
@@ -32,16 +32,15 @@ module private Private =
     type ReflectedEvent<'e> = 
         | ReflectedEvent of Id * 'e
 
-/// Wraps a mom so that it can use a direct channel for communication. This is implemented by
-/// installing an event reflector at the current node in the execution hierarchy.
-let wrap (mkNested: Channel<'e> -> 'a mom) : 'a mom = 
+/// Creates a Reflector channel and a next / driver function for the receiving part.
+let private create() : Channel<'e> * ('a flux -> 'a flux) =
     // We need a unique id to be sure that this reflector's receiver only process the events send
     // by this reflector's sender.
     let id = idGen.GenerateId()
     let queue = Queue<'e>()
 
     // For now, we send the event out _without_ going through a request of the nested IVR. This
-    // simplifies testing but reduces transparency.
+    // simplifies testing but reduces transparency. It also allows the event to be sent further up the Mom hierarchy.
     let send (ev: 'e) : unit mom = mom {
         queue.Enqueue(ev)
     }
@@ -59,6 +58,22 @@ let wrap (mkNested: Channel<'e> -> 'a mom) : 'a mom =
             else Waiting(f >> next)
         // TODO: might log if not all events are consumed
         | Completed _ as flux -> flux 
-        
+
+    (send, receive), next   
+
+
+/// Wraps a mom so that it can use a direct channel for communication. This is implemented by
+/// installing an event reflector at the current node in the execution hierarchy.
+let wrap (mkNested: Channel<'e> -> 'a mom) : 'a mom = 
+    let (send, receive), next = create()
     fun () ->
         mkNested (send, receive) () |> next
+
+/// Same as wrap, but allows to send the event from Mom contexts further up the hierarchy (but must be run in the same
+/// Runtime).
+///
+/// Returns the sender and the wrapped receiver Mom.
+let wrapReceiver (mkNested: Receiver<'e> -> 'a mom) : Sender<'e> * 'a mom =
+    let (send, receive), next = create()
+    send, fun () ->
+        mkNested receive () |> next


### PR DESCRIPTION
Since Reflector sender can schedule messages from further up the Mom control hierarchy, there should be a function that returns the sender to the caller instead of providing it to the wrapped IVR. This is perhaps the most useful scenario, for example, it makes it possible to cancel nested IVRs from further top in the control hierarchy.