### PR TITLE
Fix FSharp.Core dependency, and move to paket pack

### DIFF
--- a/Mom/Mom.fsproj
+++ b/Mom/Mom.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Description>F# computation expressions and combinators for deterministic coordination, simulation, and testing of concurrent processes.</Description>
     <PackageProjectUrl>https://github.com/pragmatrix/mom</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pragmatrix/mom</RepositoryUrl>
@@ -18,9 +18,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <None Remove="C:\Users\armin\.nuget\packages\fsharp.core\6.0.3\contentFiles\any\netstandard2.0\FSharp.Core.xml" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="Threading.fs" />
     <Compile Include="Ids.fs" />
     <Compile Include="Flux.fs" />
@@ -32,6 +29,7 @@
     <Compile Include="AsyncService.fs" />
     <Compile Include="InlineRequestService.fs" />
     <Content Include="paket.references" />
+    <None Include="Mom.paket.template" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/Mom/Mom.fsproj.paket.template
+++ b/Mom/Mom.fsproj.paket.template
@@ -1,3 +1,0 @@
-type project
-authors Armin Sander
-

--- a/Mom/Mom.paket.template
+++ b/Mom/Mom.paket.template
@@ -1,0 +1,9 @@
+type file
+id Mom
+version 1.2.0
+authors Armin Sander
+description F# computation expressions and combinators for deterministic coordination, simulation, and testing of concurrent processes.
+files
+    bin/Release/netstandard2.0/Mom.dll ==> lib/netstandard2.0
+dependencies
+    FSharp.Core >= 6.0.3

--- a/publish.sh
+++ b/publish.sh
@@ -2,5 +2,10 @@ set -ex
 dotnet tool restore
 dotnet clean -c Release
 rm -f Mom/bin/Release/*.nupkg
-dotnet pack -c Release Mom
+
+# 20250224 Moved to dotnet paket pack after attempting to require only FSharp.Core >= 6.0.3 and trying to add an appropriate nuspec file, which screwed things up completely.
+dotnet build -c Release Mom
+dotnet paket pack Mom/bin/Release
+# dotnet pack -c Release Mom
+
 dotnet nuget push Mom/bin/Release/Mom.*.nupkg --source https://www.myget.org/F/pragmatrix --api-key $MYGETAPIKEY


### PR DESCRIPTION
I've tried using a nuspec file and hell broke lose. Grok suggested to move to paket pack, and yes, this way it look quite what I've expected. Published version 1.2.0.