### PR TITLE
Directly support internal events in the runtime

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Armin Sander
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and the above permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Mom.Tests/ReflectorTests.fs
+++ b/Mom.Tests/ReflectorTests.fs
@@ -30,7 +30,7 @@ let ``Reflector sends and two parallel receiver receive it`` () =
         // send a message
         do! sender(())
         // then receive it.
-        let! _ = Mom.race [receiver(); receiver()]
+        let! _ = Mom.all [receiver(); receiver()]
         ()
     }
 

--- a/Mom.Tests/ReflectorTests.fs
+++ b/Mom.Tests/ReflectorTests.fs
@@ -8,24 +8,25 @@ let (^) = (<|)
 
 [<Fact>]
 let ``Reflector sends and receive a message``() =
+
+    let sender, receiver = Reflector.create()
     
-    let wrapped = Reflector.wrap ^ fun (sender, receiver) ->  mom {
+    let wrapped = mom {
         // send a message
         do! sender(())
         // then receive it.
         do! receiver()
     }
 
-    // Expected to complete in one go.
     wrapped
-    |> Mom.start
-    |> Flux.isCompleted
-    |> should be True
+    |> Runtime.runCore
+    |> should equal (Some ())
 
 [<Fact>]
 let ``Reflector sends and two parallel receiver receive it`` () =
     
-    let wrapped = Reflector.wrap ^ fun (sender, receiver) ->  mom {
+    let sender, receiver = Reflector.create()
+    let wrapped = mom {
         // send a message
         do! sender(())
         // then receive it.
@@ -35,6 +36,5 @@ let ``Reflector sends and two parallel receiver receive it`` () =
 
     // Expected to complete in one go.
     wrapped
-    |> Mom.start
-    |> Flux.isCompleted
-    |> should be True
+    |> Runtime.runCore
+    |> should equal (Some ())

--- a/Mom.Tests/ReflectorTests.fs
+++ b/Mom.Tests/ReflectorTests.fs
@@ -11,14 +11,14 @@ let ``Reflector sends and receive a message``() =
 
     let sender, receiver = Reflector.create()
     
-    let wrapped = mom {
+    let test = mom {
         // send a message
         do! sender(())
         // then receive it.
         do! receiver()
     }
 
-    wrapped
+    test
     |> Runtime.runCore
     |> should equal (Some ())
 
@@ -26,7 +26,7 @@ let ``Reflector sends and receive a message``() =
 let ``Reflector sends and two parallel receiver receive it`` () =
     
     let sender, receiver = Reflector.create()
-    let wrapped = mom {
+    let test = mom {
         // send a message
         do! sender(())
         // then receive it.
@@ -35,6 +35,6 @@ let ``Reflector sends and two parallel receiver receive it`` () =
     }
 
     // Expected to complete in one go.
-    wrapped
+    test
     |> Runtime.runCore
     |> should equal (Some ())

--- a/Mom/AssemblyInfo.fs
+++ b/Mom/AssemblyInfo.fs
@@ -1,0 +1,6 @@
+module Mom.AssemblyInfo
+
+open System.Runtime.CompilerServices
+
+[<assembly: InternalsVisibleTo("Mom.Tests")>]
+do ()

--- a/Mom/Mom.fs
+++ b/Mom/Mom.fs
@@ -22,7 +22,7 @@ module Mom =
     [<NoComparison;NoEquality>]
     type 'result mom = unit -> 'result flux
 
-    /// Start up an mom.
+    /// Start up a mom.
     let inline start (mom : _ mom) = mom ()
 
     /// Lifts a result.

--- a/Mom/Mom.fs
+++ b/Mom/Mom.fs
@@ -378,12 +378,12 @@ module Mom =
     type IRequest<'response> = 
         interface end
     
-    /// An Mom that synchronously sends a request to a host and returns its response. 
+    /// A Mom that synchronously sends a request to a host and returns its response. 
     let private sendUnsafe request : 'r mom = 
         fun () ->
             Requesting (box request, Result.map unbox >> Completed)
 
-    /// An Mom that synchronously sends a request to a host and returns its response. The requests
+    /// A Mom that synchronously sends a request to a host and returns its response. The requests
     /// need to implement the IRequest<_> interface so that the returned response value can be typed
     /// properly.
     let send (request: IRequest<'r>) : 'r mom = 
@@ -619,11 +619,22 @@ module Mom =
         | Delay of TimeSpan
         interface IRequest<Id>
 
+    /// Schedule an internal event to the Mom runtime currently running in. These events are delivered before all
+    /// external events. Most recent events are delivered first.
+    [<Struct>]
+    type InternalEvent =
+        | InternalEvent of obj
+        interface IRequest<unit>
+        
+    let schedule (e: 'a) : unit mom = mom {
+        do! send ^ InternalEvent (box e)
+    }
+    
     [<Struct>]    
     type CancelDelay = 
         | CancelDelay of Id
         interface IRequest<unit>
-
+    
     [<Struct>]
     type DelayCompleted = DelayCompleted of Id
 

--- a/Mom/Mom.fs
+++ b/Mom/Mom.fs
@@ -623,7 +623,7 @@ module Mom =
     /// external events. Most recent events are delivered first.
     [<Struct>]
     type InternalEvent =
-        | InternalEvent of obj
+        | InternalEvent of Event
         interface IRequest<unit>
         
     let schedule (e: 'a) : unit mom = mom {

--- a/Mom/Mom.fsproj
+++ b/Mom/Mom.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="Runtime.fs" />
     <Compile Include="AsyncService.fs" />
     <Compile Include="InlineRequestService.fs" />
+    <Compile Include="AssemblyInfo.fs" />
     <Content Include="paket.references" />
     <None Include="Mom.paket.template" />
   </ItemGroup>

--- a/Mom/Mom.fsproj
+++ b/Mom/Mom.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Description>F# computation expressions and combinators for deterministic coordination, simulation, and testing of concurrent processes.</Description>
     <PackageProjectUrl>https://github.com/pragmatrix/mom</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pragmatrix/mom</RepositoryUrl>

--- a/Mom/Mom.paket.template
+++ b/Mom/Mom.paket.template
@@ -1,6 +1,6 @@
 type file
 id Mom
-version 1.2.0
+version 1.3.0
 authors Armin Sander
 description F# computation expressions and combinators for deterministic coordination, simulation, and testing of concurrent processes.
 files

--- a/Mom/Reflector.fs
+++ b/Mom/Reflector.fs
@@ -39,7 +39,7 @@ let private create() : Channel<'e> * ('a flux -> 'a flux) =
     let id = idGen.GenerateId()
     let queue = Queue<'e>()
 
-    // For now, we send the event out _without_ going through a request of the nested IVR. This
+    // For now, we send the event out _without_ going through a request of the nested Moms. This
     // simplifies testing but reduces transparency. It also allows the event to be sent further up the Mom hierarchy.
     let send (ev: 'e) : unit mom = mom {
         queue.Enqueue(ev)

--- a/Mom/Runtime.fs
+++ b/Mom/Runtime.fs
@@ -21,6 +21,53 @@ type IServiceContext =
 
 type Host = Flux.Request -> Flux.Response
 
+/// The basic, blocking, Mom runtime function.
+/// 
+/// - `host` Handles external requests.
+/// - `eventQueue` deliver external events.
+/// - `mom` The mom to run.
+/// 
+/// Returns `None` if the Mom got cancelled, or the value computed.
+let run (host: Flux.Request -> Flux.Response) (eventQueue: SynchronizedQueue<Flux.Event>) (mom: 'a Mom.mom) : 'a option =
+    // The most recent internal event is delivered first to keep internal consistency.
+    let rec runLoop events flux =
+        match flux with
+        | Flux.Completed c -> 
+            match c with 
+            | Flux.Value r -> Some r
+            | Flux.Error e -> e.Throw(); None
+            | Flux.Cancelled -> None
+        | Flux.Requesting (request, cont) ->
+            match request with
+            | :? Mom.InternalEvent as ie ->
+                let (Mom.InternalEvent ev) = ie
+                Flux.Value (box ()) |> cont |> runLoop (ev::events)
+            | request ->
+                try host request |> Flux.Value
+                with e -> Flux.captureException e
+                |> cont |> runLoop events
+        | Flux.Waiting cont ->
+            // If there are internal events, run the most recent one first.
+            match events with
+            | ev::events ->
+                ev |> cont |> runLoop events
+            | [] ->
+                // Now process external ones.
+                match eventQueue.Dequeue() with
+                | :? CancelMom -> Flux.cancel flux
+                | event -> cont event
+                |> runLoop []
+
+    mom
+    |> Mom.start
+    |> runLoop []
+
+/// Internal function to run a Mom to completion without a host or external events.
+/// Currently used for testing only.
+let internal runCore (mom: 'a Mom.mom) =
+    mom
+    |> run (fun _ -> failwith "Received request, but there is no runtime host") (SynchronizedQueue())
+
 /// This is the runtime that drives the Mom.
 type Runtime internal (eventQueue: SynchronizedQueue<Flux.Event>, host: IServiceContext -> Host) as this = 
 
@@ -43,39 +90,7 @@ type Runtime internal (eventQueue: SynchronizedQueue<Flux.Event>, host: IService
 
     /// Runs the mom synchronously. Returns `Some(value)` or `None` if the mom was cancelled.
     member _.Run mom = 
-
-        // The most recent internal event is delivered first to keep internal consistency.
-        let rec runLoop events flux =
-            match flux with
-            | Flux.Completed c -> 
-                match c with 
-                | Flux.Value r -> Some r
-                | Flux.Error e -> e.Throw(); None
-                | Flux.Cancelled -> None
-            | Flux.Requesting (request, cont) ->
-                match request with
-                | :? Mom.InternalEvent as ie ->
-                    let (Mom.InternalEvent ev) = ie
-                    Flux.Value (box ()) |> cont |> runLoop (ev::events)
-                | request ->
-                    try host request |> Flux.Value
-                    with e -> Flux.captureException e
-                    |> cont |> runLoop events
-            | Flux.Waiting cont ->
-                // If there are internal events, run the most recent one first.
-                match events with
-                | ev::events ->
-                    ev |> cont |> runLoop events
-                | [] ->
-                    // Now process external ones.
-                    match eventQueue.Dequeue() with
-                    | :? CancelMom -> Flux.cancel flux
-                    | event -> cont event
-                    |> runLoop []
-
-        mom
-        |> Mom.start
-        |> runLoop []
+        mom |> run host eventQueue
 
     member this.Run (mom, cancellationToken: CancellationToken) = 
         use __ = cancellationToken.Register(fun () -> this.Cancel())

--- a/Mom/Runtime.fs
+++ b/Mom/Runtime.fs
@@ -44,33 +44,38 @@ type Runtime internal (eventQueue: SynchronizedQueue<Flux.Event>, host: IService
     /// Runs the mom synchronously. Returns `Some(value)` or `None` if the mom was cancelled.
     member _.Run mom = 
 
-        let rec runLoop flux =
+        // The most recent internal event is delivered first to keep internal consistency.
+        let rec runLoop events flux =
             match flux with
             | Flux.Completed c -> 
                 match c with 
-                | Flux.Value r 
-                    -> Some r
-                | Flux.Error e 
-                    -> e.Throw(); None
+                | Flux.Value r -> Some r
+                | Flux.Error e -> e.Throw(); None
                 | Flux.Cancelled -> None
-            | Flux.Requesting (request, cont) -> 
-                let result = 
-                    try
-                        host request 
-                        |> Flux.Value
-                    with e ->
-                        Flux.captureException e
-                result |> cont |> runLoop
+            | Flux.Requesting (request, cont) ->
+                match request with
+                | :? Mom.InternalEvent as ie ->
+                    let (Mom.InternalEvent ev) = ie
+                    Flux.Value (box ()) |> cont |> runLoop (ev::events)
+                | request ->
+                    try host request |> Flux.Value
+                    with e -> Flux.captureException e
+                    |> cont |> runLoop events
             | Flux.Waiting cont ->
-                let event = eventQueue.Dequeue()
-                match event with
-                | :? CancelMom -> Flux.cancel flux
-                | event -> cont event
-                |> runLoop 
+                // If there are internal events, run the most recent one first.
+                match events with
+                | ev::events ->
+                    ev |> cont |> runLoop events
+                | [] ->
+                    // Now process external ones.
+                    match eventQueue.Dequeue() with
+                    | :? CancelMom -> Flux.cancel flux
+                    | event -> cont event
+                    |> runLoop []
 
         mom
         |> Mom.start
-        |> runLoop
+        |> runLoop []
 
     member this.Run (mom, cancellationToken: CancellationToken) = 
         use __ = cancellationToken.Register(fun () -> this.Cancel())
@@ -145,7 +150,7 @@ let create builder = build builder
 /// Some predefined services that should be supported by every runtime.
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Service = 
-
+        
     let delay (context: IServiceContext) =
         let delayIdGenerator = Ids.newGenerator()
         let mutable activeTimers = Map.empty
@@ -222,7 +227,7 @@ module Service =
                 | ContinueService -> ()
                 None
 
-/// Creates a default builder, that includes the services delay, and async.
+/// Creates a default builder, that includes the services event, delay, and async.
 let newDefaultBuilder() = 
     newBuilder()
     |> withService Service.delay

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 [![build and test](https://github.com/pragmatrix/Mom/actions/workflows/mom.yml/badge.svg)](https://github.com/pragmatrix/Mom/actions/workflows/mom.yml)
+
+# Mom
+
+F# computation expressions and combinators for deterministic coordination, simulation, and testing of concurrent processes.
+
+## Installation
+
+```
+dotnet add package Mom
+```
+
+## Features
+
+- F# computation expressions
+- Deterministic process coordination
+- Test support for concurrent processes
+
+## License
+
+MIT License. See [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
A (hopefully) simpler solution to #30, see the section __Cancellable Moms__: the concept is similar and will be combined with the Reflector system.